### PR TITLE
Configure meta tables as extension config tables

### DIFF
--- a/reb_main/extn_cons.py
+++ b/reb_main/extn_cons.py
@@ -15,6 +15,8 @@ create table if not exists column_meta(
 	
 	
 );
+SELECT pg_catalog.pg_extension_config_dump('column_meta','');
+
 ---drop table service_meta cascade;
 create table if not exists  service_meta(
 	id bigserial primary key,
@@ -25,6 +27,7 @@ create table if not exists  service_meta(
 	represented_by_tables text[]  
 	
 );
+SELECT pg_catalog.pg_extension_config_dump('service_meta','');
 
 insert into service_meta(
 	service_name,


### PR DESCRIPTION
It's not totally clear to me how you're creating your extensions, but I'm pretty sure the two meta tables should be marked as extension configuration tables. See http://www.postgresql.org/docs/9.4/static/extend-extensions.html#AEN57512 for more details.

Also, it would be better if references to tables were stored as regclass[], not just text. Note that all regclass items must exist, though.
